### PR TITLE
[FC-2337][FC-656] Re-enable admin topic menu for closing/pinning/etc.

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -3745,7 +3745,6 @@ nav.post-controls {
 .topic-map,
 .topic-footer-main-buttons,
 .topic-notifications-button,
-.topic-timeline,
 .suggested-topics-message,
 a.badge-wrapper:nth-child(2),
 td.num.views, 

--- a/src/sass/common/_topic.scss
+++ b/src/sass/common/_topic.scss
@@ -104,7 +104,6 @@ nav.post-controls {
 .topic-map,
 .topic-footer-main-buttons,
 .topic-notifications-button,
-.topic-timeline,
 .suggested-topics-message,
 a.badge-wrapper:nth-child(2),
 td.num.views, 


### PR DESCRIPTION
I tested this by creating a new normal user (in my local copy of Discourse) and looking at the same post as the site admin and the normal user and the topic timeline menu was not shown to my new user (so it worked as I expected).

**I'm not familiar with the Discourse user/permissions model - should more variations should be tested?**

![admin-topic-menu](https://user-images.githubusercontent.com/96935/57729798-a6dbc400-765c-11e9-9bfa-190a9bffef71.png)
