### PR TITLE
RPLUS-35568: Direct Ask A Coach link to R+

### DIFF
--- a/src/html/common/global_navigation.html
+++ b/src/html/common/global_navigation.html
@@ -28,7 +28,7 @@ api.decorateWidget('header:before', helper => {
         fpu_link('/', 'connect', false)
       ]),
       helper.h('li', [
-        fpu_link('ask-a-coach/new', 'Ask a Coach')
+        fpu_link('https://www.ramseyplus.com/ask-a-coach', 'Ask a Coach', false)
       ]),
       helper.h('li', [
         fpu_link('classes', 'Groups')


### PR DESCRIPTION
We're now directing the "Ask a Coach" nav link in all fpu apps (`fpu-online`, `finacial-peace-courses`, etc) to **www.ramseyplus.com/ask-a-coach**